### PR TITLE
Enable grafo build and add JUnit tests

### DIFF
--- a/grafo/src/main/java/Dijkstra.java
+++ b/grafo/src/main/java/Dijkstra.java
@@ -24,7 +24,7 @@ public class Dijkstra {
         if(v != s)
         {   
             distTo[v] = Double.POSITIVE_INFINITY;
-            pq.insert(v, distTo(v));
+            pq.insert(v, distTo[v]);
 
         }
 
@@ -84,26 +84,4 @@ public class Dijkstra {
 
     
 
-}
-// Stub para DirectedEdge
-class DirectedEdge {
-    public int from() { return 0; }
-    public int to() { return 0; }
-    public double weight() { return 0.0; }
-}
-
-// Stub para EdgeWeightedIntDigraph
-class EdgeWeightedIntDigraph {
-    public int V() { return 0; }
-    public Iterable<DirectedEdge> adj(int v) { return null; }
-}
-
-// Stub para IndexMinPQ
-class IndexMinPQ<Key extends Comparable<Key>> {
-    public IndexMinPQ(int maxN) {}
-    public boolean contains(int i) { return false; }
-    public void insert(int i, Key key) {}
-    public void decreaseKey(int i, Key key) {}
-    public boolean isEmpty() { return true; }
-    public int delMin() { return 0; }
 }

--- a/grafo/src/main/java/DirectedEdge.java
+++ b/grafo/src/main/java/DirectedEdge.java
@@ -1,0 +1,5 @@
+public class DirectedEdge {
+    public int from() { return 0; }
+    public int to() { return 0; }
+    public double weight() { return 0.0; }
+}

--- a/grafo/src/main/java/Edge.java
+++ b/grafo/src/main/java/Edge.java
@@ -1,0 +1,12 @@
+public class Edge implements Comparable<Edge> {
+    private int from;
+    public Edge() {
+        this(0);
+    }
+    public Edge(int from) { this.from = from; }
+    public int from() { return from; }
+    public int either() { return from; }
+    public int other(int v) { return 0; }
+    public double weight() { return 0.0; }
+    public int compareTo(Edge that) { return Double.compare(this.weight(), that.weight()); }
+}

--- a/grafo/src/main/java/EdgeWeightedIntDigraph.java
+++ b/grafo/src/main/java/EdgeWeightedIntDigraph.java
@@ -1,0 +1,6 @@
+import java.util.Collections;
+
+public class EdgeWeightedIntDigraph {
+    public int V() { return 0; }
+    public Iterable<DirectedEdge> adj(int v) { return Collections.emptyList(); }
+}

--- a/grafo/src/main/java/EdgeWeightedIntGraph.java
+++ b/grafo/src/main/java/EdgeWeightedIntGraph.java
@@ -1,0 +1,8 @@
+import java.util.Collections;
+
+public class EdgeWeightedIntGraph {
+    public int V() { return 0; }
+    public int E() { return 0; }
+    public Iterable<Edge> adj(int v) { return Collections.emptyList(); }
+    public Iterable<Edge> edges() { return Collections.emptyList(); }
+}

--- a/grafo/src/main/java/IndexMinPQ.java
+++ b/grafo/src/main/java/IndexMinPQ.java
@@ -1,0 +1,8 @@
+public class IndexMinPQ<Key extends Comparable<Key>> {
+    public IndexMinPQ(int maxN) {}
+    public boolean contains(int i) { return false; }
+    public void insert(int i, Key key) {}
+    public void decreaseKey(int i, Key key) {}
+    public boolean isEmpty() { return true; }
+    public int delMin() { return 0; }
+}

--- a/grafo/src/main/java/Kruskal.java
+++ b/grafo/src/main/java/Kruskal.java
@@ -21,7 +21,7 @@ public class Kruskal {
      */
     public void kruskal(EdgeWeightedIntGraph G) {
 
-        Edge[] edges =new edges[G.E()];
+        Edge[] edges =new Edge[G.E()];
         int t = 0;
         for(Edge e: G.edges())
         {
@@ -69,36 +69,3 @@ public class Kruskal {
     }
 }
 
-// Stub para Edge
-// ...existing code...
-class Edge implements Comparable<Edge> {
-    private int from; // vértice de origen
-
-    public Edge(int from) {
-        this.from = from;
-    }
-
-    public int from() { return from; }
-    public int either() { return from; }
-    public int other(int v) { return 0; }
-    public double weight() { return 0.0; }
-    public int compareTo(Edge that) {
-        return Double.compare(this.weight(), that.weight());
-    }
-}
-// ...existing code...
-
-// Stub para EdgeWeightedIntGraph
-class EdgeWeightedIntGraph {
-    public int V() { return 0; }
-    public int E() { return 0; }
-    public Iterable<Edge> edges() { return null; }
-}
-
-// Stub para UF (Union-Find)
-class UF {
-    public UF(int n) {}
-    public int find(int p) { return 0; }
-    public void union(int p, int q) {}
-}
-    

--- a/grafo/src/main/java/Prim.java
+++ b/grafo/src/main/java/Prim.java
@@ -85,27 +85,3 @@ public class Prim {
     }
 }
 
-// Stub para Edge
-class Edge {
-    public int either() { return 0; }
-    public int other(int v) { return 0; }
-    public double weight() { return 0.0; }
-}
-
-// Stub para EdgeWeightedIntGraph
-class EdgeWeightedIntGraph {
-    public int V() { return 0; }
-    public Iterable<Edge> adj(int v) { return null; }
-}
-
-// Stub para IndexMinPQ
-class IndexMinPQ<Key extends Comparable<Key>> {
-    public IndexMinPQ(int maxN) {}
-    public boolean contains(int i) { return false; }
-    public void insert(int i, Key key) {}
-    public void decreaseKey(int i, Key key) {}
-    public boolean isEmpty() { return true; }
-    public int delMin() { return 0; }
-}
-    
-

--- a/grafo/src/main/java/UF.java
+++ b/grafo/src/main/java/UF.java
@@ -1,0 +1,5 @@
+public class UF {
+    public UF(int n) {}
+    public int find(int p) { return 0; }
+    public void union(int p, int q) {}
+}

--- a/grafo/src/test/java/BFSTest.java
+++ b/grafo/src/test/java/BFSTest.java
@@ -1,0 +1,10 @@
+import org.junit.jupiter.api.Test;
+
+public class BFSTest {
+    @Test
+    public void testBFSExecution() {
+        grafo g = new grafo(1);
+        DFS dfs = new DFS(g,0);
+        dfs.bfs(g,0);
+    }
+}

--- a/grafo/src/test/java/DFSTest.java
+++ b/grafo/src/test/java/DFSTest.java
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test;
+
+public class DFSTest {
+    @Test
+    public void testDFSConstructor() {
+        grafo g = new grafo(1);
+        new DFS(g,0);
+    }
+}

--- a/grafo/src/test/java/DijkstraTest.java
+++ b/grafo/src/test/java/DijkstraTest.java
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test;
+
+public class DijkstraTest {
+    @Test
+    public void testRun() {
+        EdgeWeightedIntDigraph g = new EdgeWeightedIntDigraph();
+        new Dijkstra(g,0);
+    }
+}

--- a/grafo/src/test/java/FloydWarshallTest.java
+++ b/grafo/src/test/java/FloydWarshallTest.java
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test;
+
+public class FloydWarshallTest {
+    @Test
+    public void testRun() {
+        EdgeWeightedIntDigraph g = new EdgeWeightedIntDigraph();
+        new FloydWarshall(g);
+    }
+}

--- a/grafo/src/test/java/KruskalTest.java
+++ b/grafo/src/test/java/KruskalTest.java
@@ -1,0 +1,10 @@
+import org.junit.jupiter.api.Test;
+
+public class KruskalTest {
+    @Test
+    public void testRun() {
+        EdgeWeightedIntGraph g = new EdgeWeightedIntGraph();
+        Kruskal k = new Kruskal();
+        k.kruskal(g);
+    }
+}

--- a/grafo/src/test/java/PrimTest.java
+++ b/grafo/src/test/java/PrimTest.java
@@ -1,0 +1,10 @@
+import org.junit.jupiter.api.Test;
+
+public class PrimTest {
+    @Test
+    public void testRun() {
+        EdgeWeightedIntGraph g = new EdgeWeightedIntGraph();
+        Prim p = new Prim();
+        p.prim(g,0);
+    }
+}


### PR DESCRIPTION
## Summary
- create common stub classes so `grafo` compiles
- clean up algorithm stubs
- add JUnit tests for BFS, DFS, Dijkstra, Floyd‑Warshall, Prim and Kruskal

## Testing
- `gradle test --no-daemon` *(fails: Could not resolve JUnit dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68802860a134832886d63ede6e873749